### PR TITLE
Fix Find Dialog

### DIFF
--- a/org/lateralgm/joshedit/FindDialog.java
+++ b/org/lateralgm/joshedit/FindDialog.java
@@ -112,6 +112,7 @@ public class FindDialog extends JDialog implements WindowListener, ActionListene
     pack();
     setMinimumSize(getSize());
     setIconImage(Runner.editorInterface.getIconForKey("JoshText.FIND").getImage()); //$NON-NLS-1$
+    setLocationRelativeTo(selectedJoshText);
   }
 
   /** @return Returns the static FindDialog instance. */


### PR DESCRIPTION
It should be centered at initialization. It does not matter that selectedJoshText is null Java will interpret that as centering it to the screen.

I do not actually know how or why the old JoshEdit was centering it to the screen but it was likely some sort of scenario similar to a race condition or else something just got changed along the way.

Resolves #15 
