### PR TITLE
Fixes Selection Glitchiness

### DIFF
--- a/org/lateralgm/joshedit/JoshText.java
+++ b/org/lateralgm/joshedit/JoshText.java
@@ -1235,7 +1235,6 @@ public class JoshText extends JComponent
                                                                    // overwrite caret
     int h = code.size() * lineHeight + insetY;
     setMinimumSize(new Dimension(w, h));
-    setPreferredSize(new Dimension(w, h));
     setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
     fireResize();
     repaint();


### PR DESCRIPTION
I used a view bound check to stop the view from flying outside the area which causes it to paint all glitchy. Also fixed the issue with the mouse auto update object not actually being stopped on release, it was getting immediately reactivated. These fixes address issues outlined in #20 and seem to alleviate them for the most part, though it still feels like JoshEdit could use some double buffering or else my view bounds checking is not perfect. Would appreciate if this could be pulled and tested before merged to make sure it does not cause other issues or regressions.
