### PR TITLE
Fixes Caret Center

### DIFF
--- a/org/lateralgm/joshedit/JoshText.java
+++ b/org/lateralgm/joshedit/JoshText.java
@@ -2739,10 +2739,11 @@ public class JoshText extends JComponent
   /** Handle a resize. */
   void fireResize() {
     Container a = getParent();
-    if (a == null) {
-      return;
+    int w = 0, h = 0;
+    if (a != null) {
+    	w = a.getWidth();
+    	h = a.getHeight();
     }
-    int w = a.getWidth(), h = a.getHeight();
     Dimension ps = getMinimumSize();
     ps.width = Math.max(ps.width, w);
     ps.height = Math.max(ps.height, h);


### PR DESCRIPTION
JoshEdit was not properly reporting the correct preferred size when the parent component was still null during its initialization, so JoshEdit was reporting its default preferred size of 320,240 initially causing the scrollbars to not immediately be taken into account. I believe the correct solution in this case is to at least let JoshEdit report its minimum size as the preferred size as is it still more accurate than the default size. This attempts to resolve #13

Please also note the following line.
https://github.com/JoshDreamland/JoshEdit/blob/master/org/lateralgm/joshedit/JoshText.java#L2703
