### PR TITLE
Alternative Caret Fix

### DIFF
--- a/org/lateralgm/joshedit/JoshText.java
+++ b/org/lateralgm/joshedit/JoshText.java
@@ -1235,6 +1235,7 @@ public class JoshText extends JComponent
                                                                    // overwrite caret
     int h = code.size() * lineHeight + insetY;
     setMinimumSize(new Dimension(w, h));
+    setPreferredSize(new Dimension(w, h));
     setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
     fireResize();
     repaint();


### PR DESCRIPTION
JoshEdit was not properly reporting the correct preferred size when the parent component was still null during its initialization, so JoshEdit was reporting its default preferred size of 320,240 initially causing the scrollbars to not immediately be taken into account. This second solution just sets the preferredSize in fitToCode() This attempts to resolve #13

Please also note the following line.
https://github.com/JoshDreamland/JoshEdit/blob/master/org/lateralgm/joshedit/JoshText.java#L2703
