### PR TITLE
Shifttabfix

### DIFF
--- a/org/lateralgm/joshedit/JoshText.java
+++ b/org/lateralgm/joshedit/JoshText.java
@@ -1400,16 +1400,7 @@ public class JoshText extends JComponent
           return;
         }
         Point po = p.getViewPosition();
-        
-        int x = po.x + rp.x * monoAdvance;
-        int y = po.y + rp.y * lineHeight;
-        Dimension viewSize = p.getViewSize();
-        int maxx =  viewSize.width - p.getWidth();
-        int maxy =  viewSize.height - p.getHeight();
-
-        x = x > maxx ? maxx : x;
-        y = y > maxy ? maxy : y;
-        p.setViewPosition(new Point(x < 0 ? 0 : x, y < 0 ? 0 : y));
+        p.setViewPosition(new Point(po.x + rp.x * monoAdvance, po.y + rp.y * lineHeight));
         // doShowCaret();
         updateUI();
       }
@@ -1890,10 +1881,7 @@ public class JoshText extends JComponent
         sel.special.valid = false;
       }
 
-      // if this was a mouse release then the autoscroller was stopped, so we don't want to reactivate it
-      if (e.getID() != MouseEvent.MOUSE_RELEASED) {
-      	updateMouseAutoScroll(e.getPoint());
-      }
+      updateMouseAutoScroll(e.getPoint());
 
       if (sel.special.valid) {
         sel.special.adjust();
@@ -2154,8 +2142,10 @@ public class JoshText extends JComponent
               unindent(y);
             }
           }
-          sel.col += tab.length();
-          caret.col += tab.length();
+          if (!e.isShiftDown()) {
+            sel.col += tab.length();
+            caret.col += tab.length();
+          }
           up.realize(Math.max(sel.row, caret.row));
           storeUndo(up, OPT.INDENT);
           break;


### PR DESCRIPTION
Makes the caret only move to the right when the shift button is not held, after this fix tabs work perfectly fine you can indent/unindent with the selection maintained and the caret will not go out of bounds letting you cause the exception. Attempts to resolve #19
