### PR TITLE
Center FindDialog Fix

### DIFF
--- a/org/lateralgm/joshedit/Runner.java
+++ b/org/lateralgm/joshedit/Runner.java
@@ -84,6 +84,7 @@ public class Runner {
     f.setContentPane(p);
     f.pack();
     f.setLocationRelativeTo(null);
+    FindDialog.getInstance().setLocationRelativeTo(f);
     if (closeExit) {
       f.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
     }


### PR DESCRIPTION
This was never part of JoshEdit, the issue in #15 has been resolved LGM side. But just to make the runner example for JoshEdit a little nicer I decided to make it center the FindDialog properly too. It just makes JoshEdit more presentable.
