### PR TITLE
Implements canUndo()/canRedo()

### DIFF
--- a/org/lateralgm/joshedit/JoshText.java
+++ b/org/lateralgm/joshedit/JoshText.java
@@ -3363,14 +3363,14 @@ public class JoshText extends JComponent
   private int patchIndex = 0;
 
   /**
-   * Check whether we can undo.
+   * Check whether we have available undos.
    */
   public boolean canUndo() {
-  	return patchIndex > 0;
+  	return patchIndex > 0 && undoPatches.size() > 0;
   }
   
   /**
-   * Check whether we can redo.
+   * Check whether we have available redos.
    */
   public boolean canRedo() {
   	return patchIndex < undoPatches.size();


### PR DESCRIPTION
Add undo/redo capability check to disable the buttons when not available. Note that because line change listener is fired before an undo is stored you will need to check canUndo()/canRedo() in a Swing thread invoked later.
