### PR TITLE
JEFileChooser Verify File Exists

### DIFF
--- a/org/lateralgm/joshedit/JoshText.java
+++ b/org/lateralgm/joshedit/JoshText.java
@@ -205,23 +205,60 @@ public class JoshText extends JComponent
     String getSaveFilename();
   }
 
-  private class DefaultJEFileChooser implements JEFileChooser {
-    JFileChooser fileChooser = new JFileChooser();
+  private class DefaultJEFileChooser extends JFileChooser implements JEFileChooser {
+    /**
+		 * TODO: Change if needed.
+		 */
+		private static final long serialVersionUID = 1L;
+		private boolean fileMustExist = true;
+		
+		public void setFileMustExist(boolean enable) {
+			fileMustExist  = enable;
+		}
+		
+		public boolean getFileMustExist() {
+			return fileMustExist;
+		}
 
-    @Override
+		@Override
+		public void approveSelection()
+			{
+			if (fileMustExist && this.getDialogType() == JFileChooser.OPEN_DIALOG) {
+				boolean fileExists = false;
+				if (this.isMultiSelectionEnabled()) {
+					for (File f : this.getSelectedFiles()) {
+						if (f.exists()) {
+							fileExists = true; break;
+						}
+					}
+				} else {
+					fileExists = this.getSelectedFile().exists();
+				}
+				if (!fileExists) {
+					JOptionPane.showMessageDialog(this,
+							Runner.editorInterface.getString("FileChooser.NOT_FOUND_MESSAGE"),
+							Runner.editorInterface.getString("FileChooser.NOT_FOUND_TITLE"),
+							JOptionPane.WARNING_MESSAGE);
+					return;
+				}
+			}
+			super.approveSelection();
+			}
+		
+		@Override
     public String getLoadFilename() {
-      if (fileChooser.showOpenDialog(JoshText.this) != JFileChooser.APPROVE_OPTION) {
+      if (showOpenDialog(JoshText.this) != JFileChooser.APPROVE_OPTION) {
         return null;
       }
-      return fileChooser.getSelectedFile().getPath();
+      return getSelectedFile().getPath();
     }
 
     @Override
     public String getSaveFilename() {
-      if (fileChooser.showSaveDialog(JoshText.this) != JFileChooser.APPROVE_OPTION) {
+      if (showSaveDialog(JoshText.this) != JFileChooser.APPROVE_OPTION) {
         return null;
       }
-      return fileChooser.getSelectedFile().getPath();
+      return getSelectedFile().getPath();
     }
 
   }

--- a/org/lateralgm/joshedit/JoshText.java
+++ b/org/lateralgm/joshedit/JoshText.java
@@ -876,8 +876,10 @@ public class JoshText extends JComponent
   /** Open a dialog to load the contents of the editor from a file. */
   public void Load() {
     String path = fileChooser.getLoadFilename();
-    loadFromFile(path);
-    repaint();
+    if (path != null) {
+    	loadFromFile(path);
+    	repaint();
+    }
   }
 
   /** Copy the contents of the selection to the clipboard. */

--- a/org/lateralgm/joshedit/JoshText.java
+++ b/org/lateralgm/joshedit/JoshText.java
@@ -211,6 +211,7 @@ public class JoshText extends JComponent
 		 */
 		private static final long serialVersionUID = 1L;
 		private boolean fileMustExist = true;
+		private boolean confirmOverwrite = true;
 		
 		public void setFileMustExist(boolean enable) {
 			fileMustExist  = enable;
@@ -219,27 +220,50 @@ public class JoshText extends JComponent
 		public boolean getFileMustExist() {
 			return fileMustExist;
 		}
+		
+		public void setConfirmOverwrite(boolean enable) {
+			confirmOverwrite = enable;
+		}
+		
+		public boolean getConfirmOverwrite() {
+			return confirmOverwrite;
+		}
 
+		public boolean getFileExists() {
+			boolean fileExists = false;
+			if (this.isMultiSelectionEnabled()) {
+				for (File f : this.getSelectedFiles()) {
+					if (f.exists()) {
+						fileExists = true; break;
+					}
+				}
+			} else {
+				fileExists = this.getSelectedFile().exists();
+			}
+			return fileExists;
+		}
+		
 		@Override
 		public void approveSelection()
 			{
 			if (fileMustExist && this.getDialogType() == JFileChooser.OPEN_DIALOG) {
-				boolean fileExists = false;
-				if (this.isMultiSelectionEnabled()) {
-					for (File f : this.getSelectedFiles()) {
-						if (f.exists()) {
-							fileExists = true; break;
-						}
-					}
-				} else {
-					fileExists = this.getSelectedFile().exists();
-				}
+				boolean fileExists = getFileExists();
 				if (!fileExists) {
 					JOptionPane.showMessageDialog(this,
 							Runner.editorInterface.getString("FileChooser.NOT_FOUND_MESSAGE"),
 							Runner.editorInterface.getString("FileChooser.NOT_FOUND_TITLE"),
 							JOptionPane.WARNING_MESSAGE);
 					return;
+				}
+			} else if (confirmOverwrite && this.getDialogType() == JFileChooser.SAVE_DIALOG) {
+				boolean fileExists = getFileExists();
+				if (fileExists) {
+					if (JOptionPane.showConfirmDialog(this,
+						Runner.editorInterface.getString("FileChooser.CONFIRM_OVERWRITE_MESSAGE"),
+						Runner.editorInterface.getString("FileChooser.CONFIRM_OVERWRITE_TITLE"),
+						JOptionPane.WARNING_MESSAGE) == JOptionPane.CANCEL_OPTION) {
+						return;
+					}
 				}
 			}
 			super.approveSelection();

--- a/org/lateralgm/joshedit/JoshText.java
+++ b/org/lateralgm/joshedit/JoshText.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2011 Josh Ventura <JoshV10@gmail.com>
  * Copyright (C) 2011, 2012 IsmAvatar <IsmAvatar@gmail.com>
- * Copyright (C) 2013, Robert B. Colton
+ * Copyright (C) 2013, 2014 Robert B. Colton
  *
  * This file is part of JoshEdit. JoshEdit is free software.
  * You can use, modify, and distribute it under the terms of

--- a/org/lateralgm/joshedit/JoshText.java
+++ b/org/lateralgm/joshedit/JoshText.java
@@ -726,7 +726,7 @@ public class JoshText extends JComponent
   private static boolean hasExtension(String pathName) {
     File fn = new File(pathName);
     String name = fn.getName(); // An extension contains no path characters
-    return name.lastIndexOf('.') == -1;
+    return name.lastIndexOf('.') != -1;
   }
 
   /**

--- a/org/lateralgm/joshedit/translate.properties
+++ b/org/lateralgm/joshedit/translate.properties
@@ -13,6 +13,9 @@ QuickFind.FIND_LBL    = Find:
 QuickFind.REPLACE_LBL = Replace:
 QuickFind.HIGHLIGHT   = Highlight All
 
+FileChooser.NOT_FOUND_TITLE=File not found!
+FileChooser.NOT_FOUND_MESSAGE=Check the file name and try again.
+
 FindDialog.BACKWARDS   = Search backwards
 FindDialog.CASE_SENSITIVE = Case sensitive
 FindDialog.CLOSE       = Close

--- a/org/lateralgm/joshedit/translate.properties
+++ b/org/lateralgm/joshedit/translate.properties
@@ -15,6 +15,8 @@ QuickFind.HIGHLIGHT   = Highlight All
 
 FileChooser.NOT_FOUND_TITLE=File not found!
 FileChooser.NOT_FOUND_MESSAGE=Check the file name and try again.
+FileChooser.CONFIRM_OVERWRITE_TITLE=File already exists!
+FileChooser.CONFIRM_OVERWRITE_MESSAGE=Would you like to overwrite the file anyway?
 
 FindDialog.BACKWARDS   = Search backwards
 FindDialog.CASE_SENSITIVE = Case sensitive


### PR DESCRIPTION
Extended the DefaultJEFileChooser to have the option of whether or not to check if the file exists while the open dialog is still visible and ask the user to verify the file name if it does not exist, this is what GM and most programs do. The dialog will also ask the user to confirm overwriting existing files on save. Partially resolves #36 