### PR TITLE
Formatting cleanup

### DIFF
--- a/org/lateralgm/joshedit/Code.java
+++ b/org/lateralgm/joshedit/Code.java
@@ -48,7 +48,7 @@ public class Code extends ArrayList<Line> {
   /**
    * Append a line given by a StringBuilder to the code.
    * The builder is not copied, but added by reference. Do not add the same builder multiple times.
-   * 
+   *
    * @param sb
    *        The StringBuilder representing the line to append.
    * @return True, as specified in Collection.add(E).

--- a/org/lateralgm/joshedit/JoshText.java
+++ b/org/lateralgm/joshedit/JoshText.java
@@ -908,63 +908,60 @@ public class JoshText extends JComponent
   public void ShowQuickFind() {
     finder.present();
   }
-  
-  /** Print the given page of code with line numbers based on how many lines of code will fit in the printable area */
-	public int print(LineNumberPanel lineNumPanel, Graphics g, PageFormat pf, int pageIndex) throws PrinterException
-		{	
-			//TODO: Because of banded printing the OS and printer driver may actually call this method
-			//two or more times for the same page, the first time is to help the printer determine extents.
-			//http://stackoverflow.com/questions/1943556/why-does-the-java-printables-print-method-get-called-multiple-times-with-the-sa
-			//It may be possible to get away with generating an array of BufferedImage for each page
-			//when pg.print(); is fired and just have this function look up the already rastered pages.
-			// - Robert B. Colton
-			int pageLines = (int) Math.floor(pf.getImageableHeight() / lineHeight);
-			int pageCount = (int) Math.ceil((float)getLineCount() / (float)pageLines);
-			//JOptionPane.showMessageDialog(null,pageIndex + " : " + pageLines + " : " + pageCount);
-			if (pageIndex >= pageCount) return Printable.NO_SUCH_PAGE;
-			
-			Graphics2D graphics2D = (Graphics2D) g;
-			graphics2D.translate (pf.getImageableX(), pf.getImageableY()); 
 
-			Object map = Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints"); //$NON-NLS-1$
-			if (map != null) {
-			  graphics2D.addRenderingHints((Map<?, ?>) map);
-			}
-			
-			// Editors like Studio and Eclipse usually do not paint background colors to avoid wasting the users ink.
-			// Fill background
-			//g.setColor(getBackground());
-			//g.fillRect(0, 0, pf.getImageableWidth(), pf.getImageableHeight());
-			
-			// We don't need to paint highlighters such as the currently selected line.
-			//for (Highlighter a : highlighters) {
-			 // a.paint(g, getInsets(), metrics, 0, code.size());
-			//}
-			
-			// Draw each line
-			int insetY = lineLeading + lineAscent;
-			int lastLines = pageIndex * pageLines;
-			int lineCount = getLineCount();
-			
-			if (lineNumPanel != null) {
-				lineNumPanel.printLineNumbers(g,lastLines,Math.min(pageLines,lineCount - lastLines),lineNumPanel.getLineNumberWidth(lineCount));
-				graphics2D.translate(lineNumPanel.getLineNumberWidth(lastLines + lineCount),0);
-			}
-			
-			for (int lineNum = 0; lineNum < pageLines && lineNum + lastLines < lineCount; lineNum++) {
-				//JOptionPane.showMessageDialog(null,lineNum + " : " + lineCount);
-			  drawLine(g, lineNum + lastLines, insetY + lineNum * lineHeight);
-			}
-			
-			return Printable.PAGE_EXISTS;        
-		}
+  /**
+   * Print the given page of code with line numbers based on how many lines of code will fit in the
+   * printable area.
+   */
+  public int print(LineNumberPanel lineNumPanel, Graphics g, PageFormat pf, int pageIndex)
+    throws PrinterException {
+    // TODO: Because of banded printing the OS and printer driver may actually call this method
+    // two or more times for the same page, the first time is to help the printer determine extents.
+    // http://stackoverflow.com/questions/1943556/why-does-the-java-printables-print-method-get-called-multiple-times-with-the-sa
+    // It may be possible to get away with generating an array of BufferedImage for each page when
+    // pg.print(); is fired and just have this function look up the already rastered pages.
+    // - Robert B. Colton
+    int pageLines = (int) Math.floor(pf.getImageableHeight() / lineHeight);
+    int pageCount = (int) Math.ceil((float)getLineCount() / (float)pageLines);
+    if (pageIndex >= pageCount) return Printable.NO_SUCH_PAGE;
+
+    Graphics2D graphics2D = (Graphics2D) g;
+    graphics2D.translate (pf.getImageableX(), pf.getImageableY());
+
+    Object map = Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints"); //$NON-NLS-1$
+    if (map != null) {
+      graphics2D.addRenderingHints((Map<?, ?>) map);
+    }
+
+    // Editors like Studio and Eclipse usually do not paint background colors to avoid wasting the
+    // users ink.
+    // Fill background
+    //g.setColor(getBackground());
+    //g.fillRect(0, 0, pf.getImageableWidth(), pf.getImageableHeight());
+
+    // Draw each line
+    int insetY = lineLeading + lineAscent;
+    int lastLines = pageIndex * pageLines;
+    int lineCount = getLineCount();
+
+    if (lineNumPanel != null) {
+      lineNumPanel.printLineNumbers(g,lastLines,Math.min(pageLines,lineCount - lastLines),
+        lineNumPanel.getLineNumberWidth(lineCount));
+      graphics2D.translate(lineNumPanel.getLineNumberWidth(lastLines + lineCount),0);
+    }
+
+    for (int lineNum = 0; lineNum < pageLines && lineNum + lastLines < lineCount; lineNum++) {
+        drawLine(g, lineNum + lastLines, insetY + lineNum * lineHeight);
+    }
+    return Printable.PAGE_EXISTS;
+  }
 
   /** Print the given page of code based on how many lines of code will fit in the printable area */
-	@Override
-	public int print(Graphics g, PageFormat pf, int pageIndex) throws PrinterException {
-		return print(null, g, pf, pageIndex);
-	}
-	
+  @Override
+  public int print(Graphics g, PageFormat pf, int pageIndex) throws PrinterException {
+    return print(null, g, pf, pageIndex);
+  }
+
   /** Decrease the indent for all selected lines. */
   /*
    * public void aUnindent(ActionEvent e)
@@ -984,7 +981,7 @@ public class JoshText extends JComponent
   // ===============================================================================================
   // == Wrap above methods as actions ==============================================================
   // ===============================================================================================
-	
+
   /** Cut action. */
   public AbstractAction actCut = new AbstractAction("CUT") { //$NON-NLS-1$
         private static final long serialVersionUID = 1L;
@@ -1123,21 +1120,21 @@ public class JoshText extends JComponent
       am.put(a.getValue(Action.NAME), a);
     }
   }
-  
+
   /** Map the AbstractActions provided to keyboard hotkeys. */
   public void mapAction(Action act) {
-	ActionMap am = getActionMap();
-	InputMap map = getInputMap();
-	KeyStroke[] keys = map.allKeys();
-	// Display accelerator shortcuts
-	for (KeyStroke key : keys) {
-		if (map.get(key).equals(act.getValue(Action.NAME))) {
-			act.putValue(Action.ACCELERATOR_KEY, key);
-		}
-	}
-	am.put(act.getValue(Action.NAME), act);
+    ActionMap am = getActionMap();
+    InputMap map = getInputMap();
+    KeyStroke[] keys = map.allKeys();
+    // Display accelerator shortcuts
+    for (KeyStroke key : keys) {
+      if (map.get(key).equals(act.getValue(Action.NAME))) {
+        act.putValue(Action.ACCELERATOR_KEY, key);
+      }
+    }
+    am.put(act.getValue(Action.NAME), act);
   }
-  
+
 
   /** The global find dialog. */
   FindDialog findDialog = FindDialog.getInstance();
@@ -2110,11 +2107,9 @@ public class JoshText extends JComponent
             int otype = selGetKind(code.getsb(caret.row), caret.col - 1);
             if (!sel.deleteSel()) {
               if (e.isControlDown()) {
-                // Control-Backspace on multiple lines.
-                // We'll handle this by determining the smallest
-                // word/pattern we
-                // can control-backspace over, and running with it on
-                // all lines.
+                // Control-Backspace on multiple lines. We'll handle this by determining the
+                // smallest word/pattern we can control-backspace over, and running with it on all
+                // lines.
 
                 // Nab the smallest distance
                 int mindist = -1;
@@ -2262,19 +2257,15 @@ public class JoshText extends JComponent
         up.realize(caret.row);
         storeUndo(up, OPT.TYPED);
         break;
-      case '\u0018': // cancel (not sure why it's VK_FINAL instead of
-        // VK_CANCEL)
-      case KeyEvent.VK_ESCAPE: // escape (in paramString, this is \u001B,
-        // which is VK_ESCAPE
-      case KeyEvent.CHAR_UNDEFINED:
-        // these cases are taken from KeyEvent.paramString
+      case '\u0018': // cancel (not sure why it's VK_FINAL instead of VK_CANCEL)
+      case KeyEvent.VK_ESCAPE: // escape (in paramString, this is \u001B, which is VK_ESCAPE
+      case KeyEvent.CHAR_UNDEFINED: // these cases are taken from KeyEvent.paramString
         break;
       default:
         if (e.isControlDown() || e.isAltDown()) {
           switch (e.getKeyCode()) {
-          // Handle bindings. Usually this is handled by registering key
-          // bindings,
-          // in which case it is usually consumed before it gets here.
+          // Handle bindings. Usually this is handled by registering key bindings, in which case it
+          // is usually consumed before it gets here.
             default:
               break;
           }
@@ -3443,7 +3434,7 @@ public class JoshText extends JComponent
   public boolean canUndo() {
   	return patchIndex > 0 && undoPatches.size() > 0;
   }
-  
+
   /**
    * Check whether we have available redos.
    */
@@ -3589,5 +3580,5 @@ public class JoshText extends JComponent
   public boolean isChanged() {
     return !undoPatches.isEmpty();
   }
-  
+
 }

--- a/org/lateralgm/joshedit/JoshText.java
+++ b/org/lateralgm/joshedit/JoshText.java
@@ -914,7 +914,7 @@ public class JoshText extends JComponent
    * printable area.
    */
   public int print(LineNumberPanel lineNumPanel, Graphics g, PageFormat pf, int pageIndex)
-    throws PrinterException {
+      throws PrinterException {
     // TODO: Because of banded printing the OS and printer driver may actually call this method
     // two or more times for the same page, the first time is to help the printer determine extents.
     // http://stackoverflow.com/questions/1943556/why-does-the-java-printables-print-method-get-called-multiple-times-with-the-sa
@@ -946,12 +946,12 @@ public class JoshText extends JComponent
 
     if (lineNumPanel != null) {
       lineNumPanel.printLineNumbers(g,lastLines,Math.min(pageLines,lineCount - lastLines),
-        lineNumPanel.getLineNumberWidth(lineCount));
+          lineNumPanel.getLineNumberWidth(lineCount));
       graphics2D.translate(lineNumPanel.getLineNumberWidth(lastLines + lineCount),0);
     }
 
     for (int lineNum = 0; lineNum < pageLines && lineNum + lastLines < lineCount; lineNum++) {
-        drawLine(g, lineNum + lastLines, insetY + lineNum * lineHeight);
+      drawLine(g, lineNum + lastLines, insetY + lineNum * lineHeight);
     }
     return Printable.PAGE_EXISTS;
   }

--- a/org/lateralgm/joshedit/JoshText.java
+++ b/org/lateralgm/joshedit/JoshText.java
@@ -928,7 +928,8 @@ public class JoshText extends JComponent
     Graphics2D graphics2D = (Graphics2D) g;
     graphics2D.translate (pf.getImageableX(), pf.getImageableY());
 
-    Object map = Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints"); //$NON-NLS-1$
+    Object map = Toolkit.getDefaultToolkit().getDesktopProperty(
+        "awt.font.desktophints"); //$NON-NLS-1$
     if (map != null) {
       graphics2D.addRenderingHints((Map<?, ?>) map);
     }
@@ -1811,7 +1812,8 @@ public class JoshText extends JComponent
    */
   @Override
   public void paintComponent(Graphics g) {
-    Object map = Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints"); //$NON-NLS-1$
+    Object map = Toolkit.getDefaultToolkit().getDesktopProperty(
+        "awt.font.desktophints"); //$NON-NLS-1$
     if (map != null) {
       ((Graphics2D) g).addRenderingHints((Map<?, ?>) map);
     }
@@ -1957,7 +1959,8 @@ public class JoshText extends JComponent
         sel.special.valid = false;
       }
 
-      // if this was a mouse release then the autoscroller was stopped, so we don't want to reactivate it
+      // if this was a mouse release then the autoscroller was stopped, so we don't want to
+      // reactivate it
       if (e.getID() != MouseEvent.MOUSE_RELEASED) {
       	updateMouseAutoScroll(e.getPoint());
       }
@@ -1969,7 +1972,8 @@ public class JoshText extends JComponent
       // cleanup (deselect, flash, repaint)
       if (!sel.special.valid
           && (e.getModifiers() & Event.SHIFT_MASK) == 0
-          && (e.getID() == MouseEvent.MOUSE_PRESSED || (e.getID() == MouseEvent.MOUSE_RELEASED && shouldHandleRelease))) {
+          && (e.getID() == MouseEvent.MOUSE_PRESSED
+          || (e.getID() == MouseEvent.MOUSE_RELEASED && shouldHandleRelease))) {
         sel.deselect(false);
       }
       shouldHandleRelease = false;
@@ -2595,7 +2599,8 @@ public class JoshText extends JComponent
      */
     public int getDefaultThreshold() {
       Integer ti =
-          (Integer) Toolkit.getDefaultToolkit().getDesktopProperty("DnD.gestureMotionThreshold"); //$NON-NLS-1$
+          (Integer) Toolkit.getDefaultToolkit().getDesktopProperty(
+              "DnD.gestureMotionThreshold"); //$NON-NLS-1$
       return ti == null? 5 : ti.intValue();
     }
 
@@ -3513,7 +3518,8 @@ public class JoshText extends JComponent
     while (patchIndex < undoPatches.size()) {
       undoPatches.remove(undoPatches.size() - 1);
     }
-    if (!undoCanMerge || patchIndex == 0 || !undoCompatible(undoPatches.get(patchIndex - 1), undo)) {
+    if (!undoCanMerge || patchIndex == 0
+        || !undoCompatible(undoPatches.get(patchIndex - 1), undo)) {
       undoPatches.add(undo);
       undoCanMerge = true;
       patchIndex++;

--- a/org/lateralgm/joshedit/JoshTextPanel.java
+++ b/org/lateralgm/joshedit/JoshTextPanel.java
@@ -74,7 +74,7 @@ public class JoshTextPanel extends JPanel implements Printable {
 
     find = new QuickFind(text);
     text.finder = find;
-    
+
     text.mapAction(actPrint);
 
     scroller = scrollPaneProvider.get(text);
@@ -154,49 +154,49 @@ public class JoshTextPanel extends JPanel implements Printable {
     text.caret.positionChanged();
     text.sel.selectionChanged();
   }
-  
-  /** Convenience method for displaying a print dialog returns true if successful 
-   * or false if the user cancels or an exception otherwise occurs */
+
+  /**
+   * Convenience method for displaying a print dialog returns true if successful or false if the
+   * user cancels or an exception otherwise occurs.
+   */
   public boolean Print() throws PrinterException {
-		//Step 1: Set up initial print settings.
-		PrintRequestAttributeSet aset = new HashPrintRequestAttributeSet();
-		//Step 2: Obtain a print job.
-		PrinterJob pj = PrinterJob.getPrinterJob();
-		pj.setPrintable(this);
-		//Step 3: Find print services.
-		PrintService[] services = PrinterJob.lookupPrintServices();
-		if (services.length > 0) {
-			System.out.println("selected printer: " + services[0]);
-			pj.setPrintService(services[0]);
-			// Step 4: Update the settings made by the user in the dialogs.
-			if (pj.printDialog(aset)) {
-				// Step 5: Pass the final settings into the print request.
-				pj.print(aset);
-				return true;
-			}
-		} 
-		return false;
+    //Step 1: Set up initial print settings.
+    PrintRequestAttributeSet aset = new HashPrintRequestAttributeSet();
+    //Step 2: Obtain a print job.
+    PrinterJob pj = PrinterJob.getPrinterJob();
+    pj.setPrintable(this);
+    //Step 3: Find print services.
+    PrintService[] services = PrinterJob.lookupPrintServices();
+    if (services.length > 0) {
+      pj.setPrintService(services[0]);
+      // Step 4: Update the settings made by the user in the dialogs.
+      if (pj.printDialog(aset)) {
+        // Step 5: Pass the final settings into the print request.
+        pj.print(aset);
+        return true;
+      }
+    }
+    return false;
   }
-  
+
   /** Print the given page of code with line numbers based on how many lines of code will fit in the printable area */
-	@Override
-	public int print(Graphics g, PageFormat pf, int pageIndex) throws PrinterException
-		{
-			return text.print(lines,g,pf,pageIndex);
-		}
-	
+  @Override
+  public int print(Graphics g, PageFormat pf, int pageIndex) throws PrinterException {
+    return text.print(lines,g,pf,pageIndex);
+  }
+
   /** Print action. */
   public AbstractAction actPrint = new AbstractAction("PRINT") { //$NON-NLS-1$
-			private static final long serialVersionUID = 1L;
-			
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				try {
-					Print();
-				} catch (PrinterException pe) {
-					// TODO Auto-generated catch block
-					pe.printStackTrace();
-				}
-			}
-    };
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+      try {
+        Print();
+      } catch (PrinterException pe) {
+        // TODO Auto-generated catch block
+        pe.printStackTrace();
+      }
+    }
+  };
 }

--- a/org/lateralgm/joshedit/LineNumberPanel.java
+++ b/org/lateralgm/joshedit/LineNumberPanel.java
@@ -98,23 +98,24 @@ public class LineNumberPanel extends JPanel {
     }
   }
 
-  /** 
+  /**
    * Get the width of a line number panel
-   * @param maxline the maximum line number to determine how many characters must be fit
+   * @param maxline
+   *        the maximum line number to determine how many characters must be fit
    * @return appropriate width for the line number component or to print one
    */
   public int getLineNumberWidth(int maxline) {
-	  // find the advance of the widest number
-	  int[] widths = getFontMetrics(getFont()).getWidths();
-	  int maxAdvance = 0;
-	  for (int i = '0'; i <= '9'; i++) {
-	    if (widths[i] > maxAdvance) {
-	      maxAdvance = widths[i];
-	    }
-	  }
-  	return maxAdvance * (int) Math.max(Math.log10(maxline - (startZero? 1 : 0)) + 2, 2);
+    // find the advance of the widest number
+    int[] widths = getFontMetrics(getFont()).getWidths();
+    int maxAdvance = 0;
+    for (int i = '0'; i <= '9'; i++) {
+      if (widths[i] > maxAdvance) {
+        maxAdvance = widths[i];
+      }
+    }
+    return maxAdvance * (int) Math.max(Math.log10(maxline - (startZero? 1 : 0)) + 2, 2);
   }
-  
+
   /**
    * Call upon resize to repaint.
    */
@@ -133,38 +134,42 @@ public class LineNumberPanel extends JPanel {
     // note that we can't swap out with validate() or revalidate() for some reason.
     // getParent().doLayout();
   }
-  
+
   /**
    * Paints the line number panel with special consideration for printing.
-   * @param g graphics object to use for painting
-   * @param start the first line to start on
-   * @param count the number of lines to paint from the start
-   * @param width the width of the line number area, used to ensure all pages have the same line number width
+   * @param g
+   *        graphics object to use for painting
+   * @param start
+   *        the first line to start on
+   * @param count
+   *        the number of lines to paint from the start
+   * @param width
+   *        the width of the line number area, ensures all pages have the same line number width
    */
   public void printLineNumbers(Graphics g, int start, int count, int width) {
-	  Object map = Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints"); //$NON-NLS-1$
-	  if (map != null) {
-	    ((Graphics2D) g).addRenderingHints((Map<?, ?>) map);
-	  }
-	
-	  final int insetY = metrics.getLeading() + metrics.getAscent();
-	  final int gh = metrics.getHeight();
-	  Dimension size = new Dimension(width, count * gh);
-	  int lineNum = start;
-	  final int end = size.height;
-	  
-	  // we don't want to waste the users ink, most IDE's do not print the background
-	  g.setColor(bgColor);
-	  g.fillRect(0, 0, size.width, size.height);
-	  g.setColor(fgColor);
-	
-	  g.setFont(new Font("Monospace", Font.PLAIN, 12)); //$NON-NLS-1$
-	
-	  for (int y = insetY; lineNum < lines && y <= end; lineNum++, y += gh) {
-	    String str = Integer.toString(lineNum);
-	    int strw = (int) g.getFontMetrics().getStringBounds(str, g).getWidth();
-	    g.drawString(str, size.width - strw - 3, y);
-	  }
+    Object map = Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints"); //$NON-NLS-1$
+    if (map != null) {
+      ((Graphics2D) g).addRenderingHints((Map<?, ?>) map);
+    }
+
+    final int insetY = metrics.getLeading() + metrics.getAscent();
+    final int gh = metrics.getHeight();
+    Dimension size = new Dimension(width, count * gh);
+    int lineNum = start;
+    final int end = size.height;
+
+    // we don't want to waste the users ink, most IDE's do not print the background
+    g.setColor(bgColor);
+    g.fillRect(0, 0, size.width, size.height);
+    g.setColor(fgColor);
+
+    g.setFont(new Font("Monospace", Font.PLAIN, 12)); //$NON-NLS-1$
+
+    for (int y = insetY; lineNum < lines && y <= end; lineNum++, y += gh) {
+      String str = Integer.toString(lineNum);
+      int strw = (int) g.getFontMetrics().getStringBounds(str, g).getWidth();
+      g.drawString(str, size.width - strw - 3, y);
+    }
   }
 
   /**

--- a/org/lateralgm/joshedit/gml.flex
+++ b/org/lateralgm/joshedit/gml.flex
@@ -1,9 +1,9 @@
 /*
  * Copyright (C) 2011 IsmAvatar <IsmAvatar@gmail.com>
- * 
+ *
  * This is a text editor. It's free software. You can use,
  * modify, and distribute it under the terms of the GNU
- * General Public License, version 3 or later. 
+ * General Public License, version 3 or later.
  */
 
 package org.lateralgm.joshedit;
@@ -66,7 +66,7 @@ NumberLiteral = "-"? [0-9]* "."? [0-9]+
   {EndOfLineComment}             { return COM_LINE; }
   {TraditionalComment}           { return COM_SPAN; }
   {DocumentationComment}         { return COM_DOC; }
- 
+
   /* whitespace */
   {WhiteSpace}                   { /* ignore */ }
 
@@ -74,7 +74,7 @@ NumberLiteral = "-"? [0-9]* "."? [0-9]+
 }
 
 <sDSTRING> {
-  \"                             { yybegin(YYINITIAL); 
+  \"                             { yybegin(YYINITIAL);
                                    return symbol(LIT_STR_DOUBLE, string.toString()); }
   [^\n\r\"]+                     { string.append( yytext() ); }
 }

--- a/org/lateralgm/joshedit/lexers/gmlfunctions.txt
+++ b/org/lateralgm/joshedit/lexers/gmlfunctions.txt
@@ -58,7 +58,7 @@ none
 achievement_show_challenge_notifications
 receive,local,remote
 
-achievement_show_leaderboards 
+achievement_show_leaderboards
 none
 
 ads_disable
@@ -100,7 +100,7 @@ x,y,num
 ads_setup
 user_uuid,ad_app_key
 
-ads_set_reward_callback 
+ads_set_reward_callback
 placement
 
 angle_difference
@@ -919,7 +919,7 @@ none
 device_get_tilt_y
 none
 
-device_get_tilt_z 
+device_get_tilt_z
 none
 
 directory_create
@@ -2566,7 +2566,7 @@ enable
 os_get_language
 none
 
-os_get_config 
+os_get_config
 none
 
 os_powersave_enable
@@ -4327,5 +4327,5 @@ fname
 winphone_tile_title
 title
 
-winphone_tile_wide_content 
+winphone_tile_wide_content
 string,index


### PR DESCRIPTION
This pull request attempts to bring several previous commits in line with the consistent formatting of JoshEdit. Tabs have been converted to two spaces, and the formatter was not used, this was done manually. This was to avoid certain areas being changed where existing unchanged JoshEdit code was not formatted consistently with the rest of the code base. Mostly code from my previous commits has been addressed.

@JoshDreamland 
The regular expression ( |\t)+\r was used to remove excess whitespace.

I avoided using the formatter because you had code like this...
```Java
/* comment */
CONSTANT,
/* comment */
CONSTANT,
/* comment */
CONSTANT
```
And the formatter wanted to make it...
```Java
CONSTANT, /* comment */
CONSTANT, /* comment */
CONSTANT /* comment */
```
So I didn't bother, did not want to mess up code I never touched before.