### PR TITLE
Update gmlkeywords.properties for missing gp_shoulderlb constant

### DIFF
--- a/org/lateralgm/joshedit/lexers/gmlkeywords.properties
+++ b/org/lateralgm/joshedit/lexers/gmlkeywords.properties
@@ -94,7 +94,7 @@ CONSTANTS=true false pi async_load ev_create \
  phy_joint_motor_speed phy_joint_motor_torque phy_joint_angle phy_joint_angle_limits \
  phy_joint_upper_angle_limit phy_joint_lower_angle_limit phy_joint_translation \
  phy_joint_speed phy_joint_length_1 phy_joint_length_2 phy_joint_damping_ratio phy_joint_frequency \
- gp_face1 gp_face2 gp_face3 gp_face4 gp_shoulderl gp_shoulderr gp_shoulderrb gp_shoulderrb \
+ gp_face1 gp_face2 gp_face3 gp_face4 gp_shoulderl gp_shoulderr gp_shoulderlb gp_shoulderrb \
  gp_select gp_start gp_stickl gp_stickr gp_padu gp_padd gp_padl gp_padr gp_axislh gp_axislv \
  gp_axisrh gp_axisrv buffer_generalerror buffer_invalidtype buffer_outofbounds buffer_outofspace \
  buffer_vbuffer buffer_seek_start buffer_seek_end buffer_seek_relative buffer_surface_copy \


### PR DESCRIPTION
It looks like I accidentally repeated one of the constants and forgot the one for the left should button on gamepads.