### PR TITLE
Custom Font Construction

### DIFF
--- a/src/main/java/org/lateralgm/joshedit/JoshText.java
+++ b/src/main/java/org/lateralgm/joshedit/JoshText.java
@@ -371,9 +371,9 @@ public class JoshText extends JComponent
   // == Constructors ===============================================================================
   // ===============================================================================================
 
-  /** Default constructor; delegates to JoshText(String[]). */
+  /** Default constructor; delegates to JoshText(String[], Font). */
   public JoshText() {
-    this(null);
+    this(null, null);
   }
 
   /**
@@ -381,11 +381,16 @@ public class JoshText extends JComponent
    *
    * @param lines
    *        An array of Strings; one String for each line.
+   * @param font
+   *        The font to use for painting lines. Accepts null for default monospace font.
    */
-  public JoshText(String[] lines) {
+  public JoshText(String[] lines, Font font) {
     // Drawing stuff
     setPreferredSize(new Dimension(320, 240));
-    setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+    if (font == null)
+      setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+    else
+      setFont(font);
     setBackground(backgroundColor);
     setForeground(defaultFontColor);
     setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));

--- a/src/main/java/org/lateralgm/joshedit/JoshTextPanel.java
+++ b/src/main/java/org/lateralgm/joshedit/JoshTextPanel.java
@@ -11,6 +11,7 @@
 package org.lateralgm.joshedit;
 
 import java.awt.BorderLayout;
+import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.event.ActionEvent;
 import java.awt.print.PageFormat;

--- a/src/main/java/org/lateralgm/joshedit/JoshTextPanel.java
+++ b/src/main/java/org/lateralgm/joshedit/JoshTextPanel.java
@@ -50,7 +50,7 @@ public class JoshTextPanel extends JPanel implements Printable {
   };
 
   public JoshTextPanel() {
-    this((String[]) null);
+    this((String[]) null, null);
   }
 
   public JoshTextPanel(String code) {

--- a/src/main/java/org/lateralgm/joshedit/JoshTextPanel.java
+++ b/src/main/java/org/lateralgm/joshedit/JoshTextPanel.java
@@ -61,6 +61,10 @@ public class JoshTextPanel extends JPanel implements Printable {
     this(Runner.splitLines(code), font);
   }
 
+  public JoshTextPanel(String[] codeLines) {
+    this(codeLines, null);
+  }
+
   public JoshTextPanel(String[] codeLines, Font font) {
     this(codeLines, font, true);
   }

--- a/src/main/java/org/lateralgm/joshedit/JoshTextPanel.java
+++ b/src/main/java/org/lateralgm/joshedit/JoshTextPanel.java
@@ -60,8 +60,8 @@ public class JoshTextPanel extends JPanel implements Printable {
     this(Runner.splitLines(code), font);
   }
 
-  public JoshTextPanel(String[] codeLines) {
-    this(codeLines, true);
+  public JoshTextPanel(String[] codeLines, Font font) {
+    this(codeLines, font, true);
   }
 
   public JoshTextPanel(String[] codeLines, Font font, boolean startZero) {

--- a/src/main/java/org/lateralgm/joshedit/JoshTextPanel.java
+++ b/src/main/java/org/lateralgm/joshedit/JoshTextPanel.java
@@ -55,15 +55,19 @@ public class JoshTextPanel extends JPanel implements Printable {
   public JoshTextPanel(String code) {
     this(Runner.splitLines(code));
   }
+  
+  public JoshTextPanel(String code, Font font) {
+    this(Runner.splitLines(code), font);
+  }
 
   public JoshTextPanel(String[] codeLines) {
     this(codeLines, true);
   }
 
-  public JoshTextPanel(String[] codeLines, boolean startZero) {
+  public JoshTextPanel(String[] codeLines, Font font, boolean startZero) {
     super(new BorderLayout());
 
-    text = new JoshText(codeLines);
+    text = new JoshText(codeLines, font);
     lines = new LineNumberPanel(text, text.code.size(), startZero);
     text.code.addCodeListener(new CodeListener() {
       @Override

--- a/src/main/java/org/lateralgm/joshedit/JoshTextPanel.java
+++ b/src/main/java/org/lateralgm/joshedit/JoshTextPanel.java
@@ -54,7 +54,7 @@ public class JoshTextPanel extends JPanel implements Printable {
   }
 
   public JoshTextPanel(String code) {
-    this(Runner.splitLines(code));
+    this(Runner.splitLines(code), null);
   }
   
   public JoshTextPanel(String code, Font font) {

--- a/src/main/java/org/lateralgm/joshedit/LineNumberPanel.java
+++ b/src/main/java/org/lateralgm/joshedit/LineNumberPanel.java
@@ -58,6 +58,7 @@ public class LineNumberPanel extends JPanel {
    *        True if the first line should be given index 0, false if it should be given index 1.
    */
   public LineNumberPanel(FontMetrics metrics, int lines, boolean startZero) {
+    this.setFont(new Font("Monospace", Font.PLAIN, metrics.getFont().getSize())); //$NON-NLS-1$
     this.metrics = metrics;
     this.lines = lines;
     this.startZero = startZero;
@@ -163,7 +164,7 @@ public class LineNumberPanel extends JPanel {
     g.fillRect(0, 0, size.width, size.height);
     g.setColor(fgColor);
 
-    g.setFont(new Font("Monospace", Font.PLAIN, 12)); //$NON-NLS-1$
+    g.setFont(this.getFont());
 
     for (int y = insetY; lineNum < lines && y <= end; lineNum++, y += gh) {
       String str = Integer.toString(lineNum);
@@ -202,7 +203,7 @@ public class LineNumberPanel extends JPanel {
     g.fillRect(0, 0, getWidth(), getHeight());
     g.setColor(fgColor);
 
-    g.setFont(new Font("Monospace", Font.PLAIN, 12)); //$NON-NLS-1$
+    g.setFont(this.getFont());
 
     for (int y = start; lineNum < lines && y <= end; lineNum++, y += gh) {
       String str = Integer.toString(lineNum);


### PR DESCRIPTION
This is a set of small changes so that Hugar can properly use the code editor font preference LGM has in its properties file. I don't feel like doing all of the work to finish the preferences panel Josh started in here yet, hence this self-contained pull request. I just focused on the ability to provide the font at construction time, so there's no dynamic changing the font at runtime yet either, although this change does actually make that easier to do next.

* Accept a font in the JoshText constructor, allowing null for the previous default monospace font.
* Accept a font in JoshTextPanel constructor which is passed through to JoshText.
* Change LineNumberPanel to use its set font for painting line numbers, and derive its default font's size from the font metrics passed to its constructor from JoshText.

Regardless it seems to work quite well for me up the software stack in LGM.
![12pt Code](https://user-images.githubusercontent.com/3212801/80554250-848ca480-899a-11ea-8a81-8b1c5087990f.png)
![16pt Code](https://user-images.githubusercontent.com/3212801/80554286-a1c17300-899a-11ea-960a-63ab479e220b.png)
![24pt Code](https://user-images.githubusercontent.com/3212801/80554313-bdc51480-899a-11ea-9f9c-62179ac969f2.png)
