### PR TITLE
Fix Rectangle Select Caret Painting

### DIFF
--- a/src/main/java/org/lateralgm/joshedit/Caret.java
+++ b/src/main/java/org/lateralgm/joshedit/Caret.java
@@ -145,9 +145,9 @@ public class Caret implements ActionListener {
 
   private Rectangle computeCaretRect(int selRow, ST selType) {
     Rectangle rect;
-    FontMetrics fm = painter.getFontMetrics(painter.getFont());
+    CodeMetrics cm = joshText.metrics;
     Insets i = painter.getInsets();
-    int gw = fm.getMaxAdvance(), gh = fm.getHeight();
+    int gw = cm.glyphWidth(), gh = cm.lineHeight();
     if (selType == ST.RECT) {
       rect = new Rectangle(1 + i.left + col * gw, // Position of the selection
           i.top + Math.min(row, selRow) * gh, // Top of the selection

--- a/src/main/java/org/lateralgm/joshedit/Caret.java
+++ b/src/main/java/org/lateralgm/joshedit/Caret.java
@@ -10,7 +10,6 @@
 package org.lateralgm.joshedit;
 
 import java.awt.Color;
-import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Insets;
 import java.awt.Rectangle;
@@ -24,6 +23,7 @@ import javax.swing.UIManager;
 import javax.swing.event.CaretEvent;
 import javax.swing.event.CaretListener;
 
+import org.lateralgm.joshedit.JoshText.CodeMetrics;
 import org.lateralgm.joshedit.Selection.ST;
 
 /**


### PR DESCRIPTION
This has been bugging me for a while and is not a regression, it's been this way since LateralGM 1.8.2 and I want to fix it. When you do a rectangle select, the caret paints way off from the rectangle at some horizontal column that seems to be twice the width of the selection area. The problem is that when the selection switches to rectangle mode, the character index is converted to a column that goes between tabs. I don't actually understand that much, because none of the other editors, including Scintilla, I tested treat tabs that way, but maybe Josh has seen an editor like that.

Regardless, the solution to fix the caret painting was to have it using the same metrics as the selection does to paint. This is me selecting from top-right to bottom-left by the way, to test it working in reverse. It also works in the other directions now too.


| Master | Pull |
|--------|------|
|![Master Rectangle Caret](https://user-images.githubusercontent.com/3212801/103546625-4ae93300-4e71-11eb-917b-f8ae95abe28e.png)|![Pull Rectangle Caret](https://user-images.githubusercontent.com/3212801/103546861-a0254480-4e71-11eb-855f-9f0e9d3cf85f.png)|

Another thing to mention here is that we are not flashing the caret when in rectangle mode. Every other editor, except for Eclipse, that I tested blinks the cursor in rectangle mode, Scintilla too. We might want to change that later on. There's also some other anomalies in that Visual Studio Code will actually give each line a different caret bounded to that line's width. Regular Visual Studio does the same thing but doesn't bound the caret as it seems to use virtual whitespace like JoshEdit does. However, it does paint the current row's caret a different color than the other rows in the selection.

| Visual Studio | VS Code | Eclipse |
|---------------|---------|---------|
|![Visual Studio Rectangle Select](https://user-images.githubusercontent.com/3212801/103546962-c2b75d80-4e71-11eb-9c90-6ed2ba28691e.png)|![VS Code Rectangle Select](https://user-images.githubusercontent.com/3212801/103547156-06aa6280-4e72-11eb-8873-f84af7a4c1e4.png)|![Eclipse Rectangle Select](https://user-images.githubusercontent.com/3212801/103547036-dc58a500-4e71-11eb-9298-0642883dd83f.png)|

