### PR TITLE
Fix Rectangle Caret Blink

### DIFF
--- a/src/main/java/org/lateralgm/joshedit/Caret.java
+++ b/src/main/java/org/lateralgm/joshedit/Caret.java
@@ -140,6 +140,7 @@ public class Caret implements ActionListener {
       Rectangle rect = computeCaretRect(sel.row, sel.type);
       g.fillRect(rect.x, rect.y, rect.width, rect.height);
       g.setPaintMode();
+      lastSelection = sel; // << blink
     }
   }
 


### PR DESCRIPTION
It relied upon `lastSelection` which Josh forget to set. Quick fix to just set it to the one passed to the regular paint. That way when it goes to blink, it's repainting the one it last painted. Seems to blink the entire vertical bar now for rectangle selections, as one would expect. Although again, as I said, some editors like Visual Studio and VS Code paint separate carets on each selected row.