### PR TITLE
Preserve EOF Line

### DIFF
--- a/src/main/java/org/lateralgm/joshedit/JoshText.java
+++ b/src/main/java/org/lateralgm/joshedit/JoshText.java
@@ -712,9 +712,7 @@ public class JoshText extends JComponent
       BufferedWriter bw = new BufferedWriter(new FileWriter(name));
 
       try {
-        for (int i = 0; i < code.size(); i++) {
-          bw.write(code.getsb(i).toString() + "\n"); //$NON-NLS-1$
-        }
+        bw.write(this.getText());
       } finally {
         bw.close();
       }

--- a/src/main/java/org/lateralgm/joshedit/JoshText.java
+++ b/src/main/java/org/lateralgm/joshedit/JoshText.java
@@ -695,7 +695,7 @@ public class JoshText extends JComponent
   private static boolean hasExtension(String pathName) {
     File fn = new File(pathName);
     String name = fn.getName(); // An extension contains no path characters
-    return name.lastIndexOf('.') == -1;
+    return name.lastIndexOf('.') != -1;
   }
 
   /**

--- a/src/main/java/org/lateralgm/joshedit/JoshText.java
+++ b/src/main/java/org/lateralgm/joshedit/JoshText.java
@@ -600,9 +600,10 @@ public class JoshText extends JComponent
    */
   public String getText() {
     StringBuilder res = new StringBuilder();
-    for (int i = 0; i < code.size(); i++) {
+    for (int i = 0; i < code.size()-1; i++) {
       res.append(code.get(i).sbuild.toString() + "\n"); //$NON-NLS-1$
     }
+    res.append(code.get(code.size()-1).sbuild.toString());
     return res.toString();
   }
 

--- a/src/main/java/org/lateralgm/joshedit/JoshText.java
+++ b/src/main/java/org/lateralgm/joshedit/JoshText.java
@@ -682,10 +682,8 @@ public class JoshText extends JComponent
         }
       } finally {
         br.close();
-        if (code.isEmpty()) {
-          code.add("");  //$NON-NLS-1$
-        }
       }
+      code.add(""); //<< EOF Line //$NON-NLS-1$
 
       fireLineChange(0, code.size());
       doCodeSize(true);

--- a/src/main/java/org/lateralgm/joshedit/Runner.java
+++ b/src/main/java/org/lateralgm/joshedit/Runner.java
@@ -126,6 +126,7 @@ public class Runner {
     while (sc.hasNextLine()) {
       list.add(sc.nextLine());
     }
+    list.add(""); //<< EOF Line //$NON-NLS-1$
     sc.close();
     return list.toArray(new String[0]);
   }


### PR DESCRIPTION
Making this small change to fix the script editor from always saying unsaved changes. We should keep the EOF line, which basically means guaranteeing that every file has at least one line. I made the same change to the loading and saving code. Found some other stuff busted on my way through too and fixed it.

I don't want to get too deep in this shit, so I am stopping here. However, I will say the scanners should be replaced with buffered reader to speed up the line splitting.  Scanner only makes sense for the parsing and highlighting, not for the simple loading and saving. Also may want to undo #59 and bring it back as a preference to strip the excess lines at the end of the file, except for the final standard one.

* Preserve EOF line when splitting files during initialization.
* Preserve EOF line for loading files.
* Fixed `hasExtension(...)` result negation.
* Used `getText()` helper for saving files.
* Fixed `getText()` adding an extra EOF line.